### PR TITLE
chore: 🤖 Add strict `.npmrc` file

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,8 @@
+# If set to false, then ignore package-lock.json files when installing. This will also prevent writing package-lock.json if save is true. source: https://docs.npmjs.com/cli/v11/using-npm/config
+package-lock=true
+# If true, npm does not run scripts specified in package.json files. source: https://docs.npmjs.com/cli/v11/using-npm/config#ignore-scripts
+ignore-scripts=true
+# Dependencies saved to package.json will be configured with an exact version rather than using npm's default semver range operator. source: https://docs.npmjs.com/cli/v11/using-npm/config#save-exact
+save-exact=true
+# If set to true, then npm will stubbornly refuse to install (or even consider installing) any package that claims to not be compatible with the current Node.js version. source: https://docs.npmjs.com/cli/v11/using-npm/config#engine-strict
+engine-strict=true


### PR DESCRIPTION
Add `.npmrc` with sane defaults

I tested for any packages that still needed scripts with the command `npm i && npx can-i-ignore-scripts` before introducing this.