### PR TITLE
refactor: pin GitHub Actions

### DIFF
--- a/.github/workflows/99-auto-merge.yml
+++ b/.github/workflows/99-auto-merge.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - name: ⏬ Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/99-labeler.yml
+++ b/.github/workflows/99-labeler.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-24.04 # Use Ubuntu 24.04 explicitly
     steps:
       - name: 🏷️ Labeler
-        uses: actions/labeler@v6.1.0
+        uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
         continue-on-error: true
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -14,7 +14,7 @@ jobs:
   add_labels:
     runs-on: ubuntu-24.04 # Use Ubuntu 24.04 explicitly
     steps:
-      - uses: actions-ecosystem/action-add-assignees@v1
+      - uses: actions-ecosystem/action-add-assignees@ce5019e63cc4f35aba27308dc88d19c8f3686747 # v1.0.0
         if: ${{ github.actor != 'dependabot[bot]' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -26,15 +26,15 @@ jobs:
           ]
     steps:
       - name: ⬇ Checkout repo
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
   
       - name: 🆙 Setup node
-        uses: actions/setup-node@v6.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: ".nvmrc"
 
       - name: 📥 Download deps
-        uses: bahmutov/npm-install@v1
+        uses: bahmutov/npm-install@20216767ca67f0f7b4d095dc5859c5700a6581cb # v1.12.1
         with:
           working-directory: ./${{ matrix.example }}
 
@@ -43,7 +43,7 @@ jobs:
         run: npm run build
 
       - name: ⬆ Upload build
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: ${{ matrix.example }}
           path: ./build/${{ matrix.example }}
@@ -56,28 +56,28 @@ jobs:
       image: mcr.microsoft.com/playwright:v1.50.1
     steps:
       - name: ⬇ Checkout repo
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: ⬇ Download build angular
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: angular-example
           path: ./build/angular-example
 
       - name: ⬇ Download build react
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: react-example
           path: ./build/react-example
 
       - name: ⬇ Download build vue
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: vue-example
           path: ./build/vue-example
 
       - name: 📥 Download deps
-        uses: bahmutov/npm-install@v1
+        uses: bahmutov/npm-install@20216767ca67f0f7b4d095dc5859c5700a6581cb # v1.12.1
         with:
           working-directory: ./e2e
           install-command: npm ci --ignore-scripts
@@ -94,7 +94,7 @@ jobs:
 
       - name: 🆙 Upload playwright-report
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: playwright-report
           path: ./e2e/playwright-report
@@ -102,7 +102,7 @@ jobs:
 
       - name: 🆙 Upload test results
         if: failure()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: playwright-results
           path: ./e2e/test-results


### PR DESCRIPTION
We'd like to even also pin our GitHub Actions similar to how we do it for other dependencies like pnpm as well. And we should use SHA references instead of tags to ensure an immutable reference. The versions would still be stored as a comment afterwards, which is best practice and works well with dependabot.

Tags are mutable — anyone with push access to an action's repository can move a tag to point to a different commit, potentially injecting malicious code into your workflows. Pinning to the full commit SHA makes each reference immutable: even if a tag is tampered with, your workflows will continue using the exact code you reviewed and approved. The version comment (`# v6.0.3`) preserves readability and allows Dependabot to detect and propose updates when a new version is released.